### PR TITLE
路由回调无法缓存，改为 view 方法

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -51,7 +51,5 @@ $router->namespace('\Moell\Mojito\Http\Controllers')
     });
 
 $router->namespace('\Moell\Mojito\Http\Controllers')->middleware('web')->group(function ($router) {
-    $router->get('mojito', function () {
-        return view('dashboard');
-    });
+    $router->view('mojito', 'dashboard');
 });


### PR DESCRIPTION
如果使用回调的方式，执行 `php artisan route:cache` 时会报错